### PR TITLE
Enable SQLite setup with table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dieses Projekt implementiert ein einfaches **Restaurant-Reservierungssystem** al
 ## Aufbau und Funktionsumfang
 
 - **GUI (Swing):** Ermöglicht das Anlegen neuer Reservierungen über ein Formular (Name des Gasts, Datum, Uhrzeit, Personenzahl, Tisch-Nr) sowie das Auflisten aller vorhandenen Reservierungen in einer Tabelle. Eine ausgewählte Reservierung kann per Knopfdruck wieder gelöscht werden.
-- **Datenbank (SQLite):** Die Reservierungen werden in der Datei `db/restaurant.db` gespeichert. Beim ersten Start der Anwendung wird die benötigte Tabelle automatisch angelegt. Alle Reservierungsdaten bleiben zwischen Programmstarts erhalten.
+- **Datenbank (SQLite):** Die Reservierungen werden in der Datei `db/restaurant.db` gespeichert. Beim ersten Start der Anwendung wird die benötigte Tabelle automatisch angelegt. Fehlt der Ordner `db`, wird er ebenfalls erzeugt, sodass alle Reservierungsdaten zwischen Programmstarts erhalten bleiben.
 - **Verhindern von Doppelbuchungen:** Das System prüft beim Anlegen einer Reservierung, ob für die Kombination aus Tisch-Nr und Datum/Uhrzeit bereits eine Reservierung existiert, und verhindert ggf. doppelte Einträge.
 
 ## Projektstruktur

--- a/src/main/java/com/restaurant/reservation/dao/Database.java
+++ b/src/main/java/com/restaurant/reservation/dao/Database.java
@@ -3,6 +3,7 @@ package com.restaurant.reservation.dao;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.io.File;
 
 /**
  * Hilfsklasse für die Verwaltung der Datenbankverbindung zur SQLite-DB.
@@ -25,6 +26,11 @@ public class Database {
      * @throws SQLException bei Verbindungsfehlern
      */
     public static Connection getConnection() throws SQLException {
+        // Ensure the directory for the database file exists
+        File dbDir = new File("db");
+        if (!dbDir.exists()) {
+            dbDir.mkdirs();
+        }
         return DriverManager.getConnection(DB_URL);
     }
 }

--- a/src/main/java/com/restaurant/reservation/dao/TableDAO.java
+++ b/src/main/java/com/restaurant/reservation/dao/TableDAO.java
@@ -1,6 +1,7 @@
 package com.restaurant.reservation.dao;
 
 import com.restaurant.reservation.model.Table;
+import com.restaurant.reservation.dao.Database;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -12,11 +13,27 @@ import java.util.List;
  */
 public class TableDAO {
 
-    private static final String DB_URL = "jdbc:sqlite:restaurant.db";
-
     /** Stellt eine Verbindung zur SQLite-Datenbank her. */
     private Connection connect() throws SQLException {
-        return DriverManager.getConnection(DB_URL);
+        return Database.getConnection();
+    }
+
+    /**
+     * Legt die Tabelle "tables" an, falls sie noch nicht existiert.
+     */
+    public static void createTable() {
+        String sql = "CREATE TABLE IF NOT EXISTS tables (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "name TEXT NOT NULL," +
+                "seats INTEGER NOT NULL," +
+                "hasProjector INTEGER NOT NULL)";
+        try (Connection conn = Database.getConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate(sql);
+        } catch (SQLException e) {
+            System.err.println("Fehler beim Erstellen der Tisch-Tabelle: " + e.getMessage());
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -112,7 +129,7 @@ public class TableDAO {
      * @throws SQLException falls ein DB-Zugriffsfehler auftritt
      */
     public boolean isTableUsed(int id) throws SQLException {
-        String sql = "SELECT COUNT(*) FROM reservations WHERE table_id = ?";
+        String sql = "SELECT COUNT(*) FROM reservations WHERE table_number = ?";
         try (Connection conn = connect();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setInt(1, id);

--- a/src/main/java/com/restaurant/reservation/ui/MainApp.java
+++ b/src/main/java/com/restaurant/reservation/ui/MainApp.java
@@ -1,6 +1,7 @@
 package com.restaurant.reservation.ui;
 
 import com.restaurant.reservation.dao.ReservationDAO;
+import com.restaurant.reservation.dao.TableDAO;
 import com.restaurant.reservation.service.ReservationService;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
@@ -18,8 +19,9 @@ public class MainApp {
             // Ignorieren, falls nicht erfolgreich gesetzt
         }
 
-        // Datenbank-Tabelle erstellen (falls noch nicht vorhanden)
+        // Datenbank-Tabellen erstellen (falls noch nicht vorhanden)
         ReservationDAO.createTable();
+        TableDAO.createTable();
 
         // Service und GUI starten
         ReservationService service = new ReservationService();


### PR DESCRIPTION
## Summary
- ensure the `db` directory exists before connecting
- add DAO for managing the `tables` table and use shared connection
- create reservation and table tables during startup
- update documentation about automatic `db` directory creation
- track empty `db` folder

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68673df5be8083298465e3308e3f3f33