### PR TITLE
Seed example tables on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Dieses Projekt implementiert ein einfaches **Restaurant-Reservierungssystem** al
 ## Aufbau und Funktionsumfang
 
 - **GUI (Swing):** Ermöglicht das Anlegen neuer Reservierungen über ein Formular (Name des Gasts sowie Auswahl von Datum, Uhrzeit, Personenzahl und Tisch-Nr über Dropdown-Menüs) und listet alle vorhandenen Reservierungen in einer Tabelle auf. Eine ausgewählte Reservierung kann per Knopfdruck wieder gelöscht werden.
-- **Datenbank (SQLite):** Die Reservierungen werden in der Datei `db/restaurant.db` gespeichert. Beim ersten Start der Anwendung wird die benötigte Tabelle automatisch angelegt. Fehlt der Ordner `db`, wird er ebenfalls erzeugt, sodass alle Reservierungsdaten zwischen Programmstarts erhalten bleiben.
+- **Datenbank (SQLite):** Die Reservierungen werden in der Datei `db/restaurant.db` gespeichert. Beim ersten Start der Anwendung wird die benötigte Tabelle automatisch angelegt. Fehlt der Ordner `db`, wird er ebenfalls erzeugt, sodass alle Reservierungsdaten zwischen Programmstarts erhalten bleiben. Sind noch keine Tische vorhanden, legt das Programm zudem 15 Beispiel-Tische mit unterschiedlichen Sitzplatzanzahlen an.
 - **Verhindern von Doppelbuchungen:** Das System prüft beim Anlegen einer Reservierung, ob für die Kombination aus Tisch-Nr und Datum/Uhrzeit bereits eine Reservierung existiert, und verhindert ggf. doppelte Einträge.
 
 ## Projektstruktur

--- a/src/main/java/com/restaurant/reservation/dao/TableDAO.java
+++ b/src/main/java/com/restaurant/reservation/dao/TableDAO.java
@@ -30,6 +30,21 @@ public class TableDAO {
         try (Connection conn = Database.getConnection();
              Statement stmt = conn.createStatement()) {
             stmt.executeUpdate(sql);
+
+            // Beispiel-Daten einfügen, falls noch keine Tische vorhanden sind
+            try (ResultSet rs = stmt.executeQuery("SELECT COUNT(*) FROM tables")) {
+                if (rs.next() && rs.getInt(1) == 0) {
+                    String insert = "INSERT INTO tables (name, seats, hasProjector) VALUES (?, ?, ?)";
+                    try (PreparedStatement ps = conn.prepareStatement(insert)) {
+                        for (int i = 1; i <= 15; i++) {
+                            ps.setString(1, "Tisch " + i);
+                            ps.setInt(2, 2 + (i % 7)); // Sitzplätze 2-8
+                            ps.setInt(3, 0); // kein Projektor
+                            ps.executeUpdate();
+                        }
+                    }
+                }
+            }
         } catch (SQLException e) {
             System.err.println("Fehler beim Erstellen der Tisch-Tabelle: " + e.getMessage());
             e.printStackTrace();


### PR DESCRIPTION
## Summary
- seed database with 15 example tables when empty
- document automatic table generation in README

## Testing
- `mvn -q test` *(fails: Could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68676271acb48329a620a48abb59fa39