### PR TITLE
Improve dashboard layout

### DIFF
--- a/src/main/java/com/restaurant/reservation/ui/DashboardFrame.java
+++ b/src/main/java/com/restaurant/reservation/ui/DashboardFrame.java
@@ -2,6 +2,8 @@ package com.restaurant.reservation.ui;
 
 import com.restaurant.reservation.model.Reservation;
 import com.restaurant.reservation.service.ReservationService;
+import com.restaurant.reservation.service.TableService;
+import com.restaurant.reservation.model.Table;
 import com.restaurant.reservation.ui.FloorPlanFrame;
 import com.restaurant.reservation.ui.StatisticsFrame;
 
@@ -13,7 +15,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Hauptfenster (Dashboard) mit heutigen Reservierungen und Navigation.
+ * Hauptfenster (Dashboard) mit Tischplan und 
+ * einer kleinen Liste der kommenden Reservierungen.
  */
 public class DashboardFrame extends JFrame {
     private final ReservationService reservationService;
@@ -28,17 +31,25 @@ public class DashboardFrame extends JFrame {
         setLayout(new BorderLayout(10,10));
         ((JComponent) getContentPane()).setBorder(BorderFactory.createEmptyBorder(10,10,10,10));
 
-        JLabel headline = new JLabel("Heutige Reservierungen");
-        headline.setFont(headline.getFont().deriveFont(Font.BOLD, 18f));
-        add(headline, BorderLayout.NORTH);
+        // Panel mit Tischplan in der Mitte
+        JLayeredPane floorPlanPane = createFloorPlanPane();
+        add(floorPlanPane, BorderLayout.CENTER);
 
-        String[] cols = {"Uhrzeit","Personen","Tisch","Gast"};
+        // Panel für die nächsten Reservierungen in der rechten Ecke
+        String[] cols = {"Datum","Uhrzeit","Tisch","Gast"};
         tableModel = new DefaultTableModel(cols,0) {
             @Override
             public boolean isCellEditable(int row, int col) { return false; }
         };
         reservationTable = new JTable(tableModel);
-        add(new JScrollPane(reservationTable), BorderLayout.CENTER);
+        JScrollPane tableScroll = new JScrollPane(reservationTable);
+        tableScroll.setPreferredSize(new Dimension(250, 0));
+        JPanel reservationPanel = new JPanel(new BorderLayout());
+        JLabel headline = new JLabel("Nächste Reservierungen");
+        headline.setFont(headline.getFont().deriveFont(Font.BOLD, 16f));
+        reservationPanel.add(headline, BorderLayout.NORTH);
+        reservationPanel.add(tableScroll, BorderLayout.CENTER);
+        add(reservationPanel, BorderLayout.EAST);
 
         JButton newResButton = new JButton("Neue Reservierung");
         JButton allResButton = new JButton("Alle Reservierungen");
@@ -82,20 +93,72 @@ public class DashboardFrame extends JFrame {
         refreshTable();
     }
 
-    /** Reload today's reservations */
+    /**
+     * Lädt die kommenden Reservierungen (heute bis 7 Tage im Voraus)
+     * und aktualisiert die Tabelle im Dashboard.
+     */
     public void refreshTable() {
         try {
             List<Reservation> all = reservationService.getAllReservations();
             reservations.clear();
             tableModel.setRowCount(0);
+            LocalDate today = LocalDate.now();
+            LocalDate limit = today.plusDays(7);
             for (Reservation r : all) {
-                if (LocalDate.parse(r.getDate()).isEqual(LocalDate.now())) {
+                LocalDate date = LocalDate.parse(r.getDate());
+                if (!date.isBefore(today) && !date.isAfter(limit)) {
                     reservations.add(r);
-                    tableModel.addRow(new Object[]{r.getTime(), r.getPersons(), r.getTableNumber(), r.getName()});
+                    tableModel.addRow(new Object[]{r.getDate(), r.getTime(), r.getTableNumber(), r.getName()});
                 }
             }
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this, "Reservierungen konnten nicht geladen werden.", "Fehler", JOptionPane.ERROR_MESSAGE);
         }
+    }
+
+    /** Erstellt das Panel mit dem Tischplan. */
+    private JLayeredPane createFloorPlanPane() {
+        JLayeredPane pane = new JLayeredPane();
+        pane.setLayout(null);
+
+        TableService tableService = new TableService();
+        java.util.List<Table> tables;
+        try {
+            tables = tableService.getAllTables();
+        } catch (java.sql.SQLException e) {
+            tables = java.util.Collections.emptyList();
+        }
+
+        int x = 20, y = 20;
+        for (Table t : tables) {
+            JLabel lbl = createDraggableLabel("T" + t.getId());
+            lbl.setBounds(x, y, 60, 40);
+            pane.add(lbl);
+            x += 70;
+            if (x > 500) { x = 20; y += 50; }
+        }
+
+        return pane;
+    }
+
+    /** Erstellt ein verschiebbares Label für den Tischplan. */
+    private JLabel createDraggableLabel(String text) {
+        JLabel lbl = new JLabel(text, SwingConstants.CENTER);
+        lbl.setOpaque(true);
+        lbl.setBackground(new Color(222,184,135));
+        lbl.setBorder(BorderFactory.createLineBorder(Color.DARK_GRAY));
+        java.awt.event.MouseAdapter ma = new java.awt.event.MouseAdapter() {
+            Point offset;
+            @Override public void mousePressed(java.awt.event.MouseEvent e) {
+                offset = e.getPoint();
+            }
+            @Override public void mouseDragged(java.awt.event.MouseEvent e) {
+                Point p = SwingUtilities.convertPoint(lbl, e.getPoint(), lbl.getParent());
+                lbl.setLocation(p.x - offset.x, p.y - offset.y);
+            }
+        };
+        lbl.addMouseListener(ma);
+        lbl.addMouseMotionListener(ma);
+        return lbl;
     }
 }


### PR DESCRIPTION
## Summary
- integrate table layout directly into `DashboardFrame`
- show upcoming reservations in a small side panel

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686766f4c190832988935050f90e2f57