### PR TITLE
Fix table capacity validation and remove projector option

### DIFF
--- a/src/main/java/com/restaurant/reservation/dao/TableDAO.java
+++ b/src/main/java/com/restaurant/reservation/dao/TableDAO.java
@@ -157,4 +157,28 @@ public class TableDAO {
         }
         return false;
     }
+
+    /**
+     * Sucht einen Tisch anhand seiner ID.
+     *
+     * @param id die Tisch-ID
+     * @return das gefundene {@link Table}-Objekt oder {@code null}, wenn kein Eintrag existiert
+     * @throws SQLException bei Datenbankfehlern
+     */
+    public Table findTableById(int id) throws SQLException {
+        String sql = "SELECT id, name, seats, hasProjector FROM tables WHERE id = ?";
+        try (Connection conn = connect();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, id);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    String name = rs.getString("name");
+                    int seats = rs.getInt("seats");
+                    boolean hasProjector = rs.getInt("hasProjector") == 1;
+                    return new Table(id, name, seats, hasProjector);
+                }
+            }
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/restaurant/reservation/service/TableService.java
+++ b/src/main/java/com/restaurant/reservation/service/TableService.java
@@ -62,4 +62,15 @@ public class TableService {
         // Wenn nicht verwendet, löschen
         tableDAO.delete(id);
     }
+
+    /**
+     * Liefert einen Tisch anhand seiner ID.
+     *
+     * @param id die Tisch-ID
+     * @return das Tisch-Objekt oder {@code null}, wenn kein Tisch existiert
+     * @throws SQLException falls beim Datenbankzugriff ein Fehler auftritt
+     */
+    public Table getTableById(int id) throws SQLException {
+        return tableDAO.findTableById(id);
+    }
 }

--- a/src/main/java/com/restaurant/reservation/ui/ReservationFormFrame.java
+++ b/src/main/java/com/restaurant/reservation/ui/ReservationFormFrame.java
@@ -1,6 +1,7 @@
 package com.restaurant.reservation.ui;
 
 import com.restaurant.reservation.service.ReservationService;
+import com.restaurant.reservation.service.TableService;
 
 import javax.swing.*;
 import java.awt.*;
@@ -20,9 +21,9 @@ public class ReservationFormFrame extends JFrame {
     private JComboBox<String> dateCombo;
     private JComboBox<String> timeCombo;
     private JTextField nameField;
-    private JCheckBox projectorBox;
     private JLabel tableLabel;
     private Integer selectedTable;
+    private final TableService tableService = new TableService();
 
     public ReservationFormFrame(DashboardFrame dashboard, ReservationService service) {
         this.dashboard = dashboard;
@@ -61,8 +62,6 @@ public class ReservationFormFrame extends JFrame {
         nameField = new JTextField();
         formPanel.add(nameField);
 
-        projectorBox = new JCheckBox("Projektor benötigt");
-        formPanel.add(projectorBox);
         JButton selectTableBtn = new JButton("Tisch auswählen");
         formPanel.add(selectTableBtn);
 
@@ -91,8 +90,7 @@ public class ReservationFormFrame extends JFrame {
         String date = (String) dateCombo.getSelectedItem();
         String time = (String) timeCombo.getSelectedItem();
         int persons = (Integer) personsCombo.getSelectedItem();
-        boolean proj = projectorBox.isSelected();
-        TableSelectionDialog dialog = new TableSelectionDialog(this, reservationService, date, time, persons, proj);
+        TableSelectionDialog dialog = new TableSelectionDialog(this, reservationService, date, time, persons);
         dialog.setVisible(true);
         Integer tbl = dialog.getSelectedTable();
         if (tbl != null) {
@@ -108,6 +106,16 @@ public class ReservationFormFrame extends JFrame {
         int persons = (Integer) personsCombo.getSelectedItem();
         if (name.isEmpty() || selectedTable == null) {
             JOptionPane.showMessageDialog(this, "Bitte Name und Tisch auswählen.");
+            return;
+        }
+        try {
+            com.restaurant.reservation.model.Table tbl = tableService.getTableById(selectedTable);
+            if (tbl != null && persons > tbl.getSeats()) {
+                JOptionPane.showMessageDialog(this, "Gewählter Tisch hat nicht genug Sitzplätze.");
+                return;
+            }
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, "Konnte Sitzplatzanzahl nicht prüfen.", "Fehler", JOptionPane.WARNING_MESSAGE);
             return;
         }
         try {

--- a/src/main/java/com/restaurant/reservation/ui/TableSelectionDialog.java
+++ b/src/main/java/com/restaurant/reservation/ui/TableSelectionDialog.java
@@ -22,16 +22,14 @@ public class TableSelectionDialog extends JDialog {
     private final String date;
     private final String time;
     private final int persons;
-    private final boolean projector;
 
 
-    public TableSelectionDialog(Window owner, ReservationService service, String date, String time, int persons, boolean projector) {
+    public TableSelectionDialog(Window owner, ReservationService service, String date, String time, int persons) {
         super(owner, "Tisch auswählen", ModalityType.APPLICATION_MODAL);
         this.reservationService = service;
         this.date = date;
         this.time = time;
         this.persons = persons;
-        this.projector = projector;
         buildUi();
         loadData();
     }
@@ -81,7 +79,6 @@ public class TableSelectionDialog extends JDialog {
         model.setRowCount(0);
         for (Table t : tables) {
             if (t.getSeats() < persons) continue;
-            if (projector && !t.isHasProjector()) continue;
             boolean reserved = false;
             try {
                 reserved = reservationService.isTableReserved(date, time, t.getId());


### PR DESCRIPTION
## Summary
- add method to fetch table by id
- expose table retrieval via TableService
- remove projector filter and checkbox from reservation form
- validate table capacity against number of people
- adjust table selection dialog constructor

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_686a75d068748329923f5ac37b16d388