### PR TITLE
Implement no-show tracking

### DIFF
--- a/src/main/java/com/restaurant/reservation/model/Reservation.java
+++ b/src/main/java/com/restaurant/reservation/model/Reservation.java
@@ -17,12 +17,14 @@ public class Reservation {
     private int persons;
     /** Tisch-Nummer im Restaurant */
     private int tableNumber;
+    /** Status der Reservierung (PENDING, ATTENDED oder NOSHOW) */
+    private String status;
 
     /**
      * Konstruktor für eine neue Reservierung (ohne ID, z.B. vor Datenbank-Speicherung).
      */
     public Reservation(String name, String date, String time, int persons, int tableNumber) {
-        this(null, name, date, time, persons, tableNumber);
+        this(null, name, date, time, persons, tableNumber, "PENDING");
     }
 
     /**
@@ -34,13 +36,21 @@ public class Reservation {
      * @param persons Anzahl der Personen
      * @param tableNumber Tisch-Nummer
      */
-    public Reservation(Integer id, String name, String date, String time, int persons, int tableNumber) {
+    public Reservation(Integer id, String name, String date, String time, int persons, int tableNumber, String status) {
         this.id = id;
         this.name = name;
         this.date = date;
         this.time = time;
         this.persons = persons;
         this.tableNumber = tableNumber;
+        this.status = status;
+    }
+
+    /**
+     * Kompatibilitätskonstruktor ohne Status.
+     */
+    public Reservation(Integer id, String name, String date, String time, int persons, int tableNumber) {
+        this(id, name, date, time, persons, tableNumber, "PENDING");
     }
 
     public Integer getId() {
@@ -89,5 +99,13 @@ public class Reservation {
 
     public void setTableNumber(int tableNumber) {
         this.tableNumber = tableNumber;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
     }
 }

--- a/src/main/java/com/restaurant/reservation/service/ReservationService.java
+++ b/src/main/java/com/restaurant/reservation/service/ReservationService.java
@@ -126,4 +126,31 @@ public class ReservationService {
             throw new Exception("Datenbankfehler beim Laden der Reservierungen.", e);
         }
     }
+
+    /** Setzt den Status einer Reservierung. */
+    public void setStatus(int reservationId, String status) throws Exception {
+        try {
+            dao.updateStatus(reservationId, status);
+        } catch (SQLException e) {
+            throw new Exception("Datenbankfehler beim Aktualisieren des Status.", e);
+        }
+    }
+
+    /** Anzahl der No-Shows. */
+    public int getNoShowCount() throws Exception {
+        try {
+            return dao.countNoShows();
+        } catch (SQLException e) {
+            throw new Exception("Datenbankfehler beim Zählen der No-Shows.", e);
+        }
+    }
+
+    /** Anzahl der als erschienen markierten Reservierungen. */
+    public int getAttendedCount() throws Exception {
+        try {
+            return dao.countAttended();
+        } catch (SQLException e) {
+            throw new Exception("Datenbankfehler beim Zählen der Besuche.", e);
+        }
+    }
 }

--- a/src/main/java/com/restaurant/reservation/ui/ReservationListFrame.java
+++ b/src/main/java/com/restaurant/reservation/ui/ReservationListFrame.java
@@ -25,16 +25,24 @@ public class ReservationListFrame extends JFrame {
         setLayout(new BorderLayout(10,10));
         ((JComponent)getContentPane()).setBorder(BorderFactory.createEmptyBorder(10,10,10,10));
 
-        model = new DefaultTableModel(new Object[]{"Datum","Uhrzeit","Tisch","Gast"},0) {
+        model = new DefaultTableModel(new Object[]{"Datum","Uhrzeit","Tisch","Gast","Status"},0) {
             @Override public boolean isCellEditable(int r,int c){return false;}
         };
         table = new JTable(model);
         add(new JScrollPane(table), BorderLayout.CENTER);
 
         JButton deleteBtn = new JButton("Stornieren");
-        add(deleteBtn, BorderLayout.SOUTH);
+        JButton attendBtn = new JButton("Anwesend");
+        JButton noShowBtn = new JButton("No-Show");
+        JPanel south = new JPanel();
+        south.add(deleteBtn);
+        south.add(attendBtn);
+        south.add(noShowBtn);
+        add(south, BorderLayout.SOUTH);
 
         deleteBtn.addActionListener(e -> onDelete());
+        attendBtn.addActionListener(e -> setStatus("ATTENDED"));
+        noShowBtn.addActionListener(e -> setStatus("NOSHOW"));
 
         setSize(600,400);
         setLocationRelativeTo(null);
@@ -46,7 +54,7 @@ public class ReservationListFrame extends JFrame {
             reservations = service.getAllReservations();
             model.setRowCount(0);
             for (Reservation r : reservations) {
-                model.addRow(new Object[]{r.getDate(), r.getTime(), r.getTableNumber(), r.getName()});
+                model.addRow(new Object[]{r.getDate(), r.getTime(), r.getTableNumber(), r.getName(), r.getStatus()});
             }
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this, "Reservierungen konnten nicht geladen werden.");
@@ -64,6 +72,21 @@ public class ReservationListFrame extends JFrame {
         if (confirm != JOptionPane.YES_OPTION) return;
         try {
             service.deleteReservation(res.getId());
+            loadData();
+        } catch (Exception ex) {
+            JOptionPane.showMessageDialog(this, ex.getMessage(), "Fehler", JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    private void setStatus(String status) {
+        int row = table.getSelectedRow();
+        if (row < 0) {
+            JOptionPane.showMessageDialog(this, "Bitte eine Reservierung auswählen.");
+            return;
+        }
+        Reservation res = reservations.get(row);
+        try {
+            service.setStatus(res.getId(), status);
             loadData();
         } catch (Exception ex) {
             JOptionPane.showMessageDialog(this, ex.getMessage(), "Fehler", JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/com/restaurant/reservation/ui/StatisticsFrame.java
+++ b/src/main/java/com/restaurant/reservation/ui/StatisticsFrame.java
@@ -28,10 +28,15 @@ public class StatisticsFrame extends JFrame {
         try {
             int reservations = service.getReservationCount();
             int cancels = service.getCancellationCount();
+            int noShows = service.getNoShowCount();
+            int attended = service.getAttendedCount();
             double cancelRate = reservations + cancels == 0 ? 0 : (double)cancels/(reservations+cancels)*100.0;
+            double noShowRate = attended + noShows == 0 ? 0 : (double)noShows/(attended+noShows)*100.0;
             content.add(new JLabel("Aktuelle Reservierungen: " + reservations));
             content.add(new JLabel("Stornierungen gesamt: " + cancels));
             content.add(new JLabel("Stornierungsrate: " + String.format("%.1f%%", cancelRate)));
+            content.add(new JLabel("No-Shows gesamt: " + noShows));
+            content.add(new JLabel("No-Show-Rate: " + String.format("%.1f%%", noShowRate)));
             List<String> popular = service.getPopularTimes(3);
             content.add(new JLabel("Beliebteste Zeiten: " + String.join(", ", popular)));
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- add `status` field to `Reservation` to mark attendance
- extend `ReservationDAO` with status CRUD and counts
- support status updates via `ReservationService`
- show status in `ReservationListFrame` with actions to mark attended or no-show
- display no-show statistics in `StatisticsFrame`

## Testing
- `mvn test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_686fcfdcee148329a2e0e132cdfbf7f7