### PR TITLE
Fix duplicate column error on startup

### DIFF
--- a/src/main/java/com/restaurant/reservation/dao/ReservationDAO.java
+++ b/src/main/java/com/restaurant/reservation/dao/ReservationDAO.java
@@ -64,12 +64,11 @@ public class ReservationDAO {
                 stmt.executeUpdate("ALTER TABLE reservations ADD COLUMN status TEXT NOT NULL DEFAULT 'PENDING'");
             }
             if (!hasCreated) {
-
-                
+                // SQLite erlaubt beim Hinzufügen neuer Spalten keinen Funktion-Ausdruck
+                // als DEFAULT-Wert. Daher wird die Spalte zunächst ohne NOT NULL-Constraint
+                // angelegt und anschließend mit dem aktuellen Zeitpunkt befüllt.
                 stmt.executeUpdate("ALTER TABLE reservations ADD COLUMN created_at TEXT");
                 stmt.executeUpdate("UPDATE reservations SET created_at = datetime('now') WHERE created_at IS NULL");
-
-                stmt.executeUpdate("ALTER TABLE reservations ADD COLUMN created_at TEXT NOT NULL DEFAULT (datetime('now'))");
             }
             if (!hasConfirmed) {
                 stmt.executeUpdate("ALTER TABLE reservations ADD COLUMN confirmed_at TEXT");


### PR DESCRIPTION
## Summary
- avoid adding `created_at` column twice when upgrading database

## Testing
- `mvn -q -DskipTests=false test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e61fec38832982132c7021b8543b